### PR TITLE
Improved footer dark-13

### DIFF
--- a/Footer/src/footer-dark-13.html
+++ b/Footer/src/footer-dark-13.html
@@ -1,215 +1,134 @@
-<footer style="background-color: #00007B " class="p-16">
-    <div class="flex flex-wrap gap-8 justify-center sm:justify-evenly">
-      <div>
-        <h5 class="pb-10 font-bold text-slate-100">Bali</h5>
-        <ul>
-          <li class="pb-1 text-slate-100"><a href="#">Balakant Samat</a></li>
-          <li class="pb-1 text-slate-100"><a href="#">Gang Bekul Canggu-Kuta,</a></li>
-          <li class="pb-1 text-slate-100"><a href="#">Indonesia</a></li>
-        </ul>
-        <br>
-        <div>
-          <nav class="mb-10 list-none">
-                    <li class="mb-2">
-                        <a
-                            class="flex justify-center text-gray-600 hover:text-gray-800 md:justify-start">
-                            <div class="flex">
-                                <svg
-                                    xmlns="http://www.w3.org/2000/svg"
-                                    viewBox="0 0 24 24"
-                                    fill="currentColor"
-                                    class="h-6 w-6"
-                                >
-                                    <path
-                                        fill-rule="evenodd"
-                                        d="M1.5 4.5a3 3 0 013-3h1.372c.86 0 1.61.586 1.819 1.42l1.105 4.423a1.875 1.875 0 01-.694 1.955l-1.293.97c-.135.101-.164.249-.126.352a11.285 11.285 0 006.697 6.697c.103.038.25.009.352-.126l.97-1.293a1.875 1.875 0 011.955-.694l4.423 1.105c.834.209 1.42.959 1.42 1.82V19.5a3 3 0 01-3 3h-2.25C8.552 22.5 1.5 15.448 1.5 6.75V4.5z"
-                                        clip-rule="evenodd"
-                                    /></svg
-                                ><span class="ml-3">Berryl: +12(3)4567890123</span>
-                            </div></a
-                        >
-                    </li>
-                    <nav class="mb-10 list-none">
-                    <li class="mb-2">
-                        <a
-                            class="flex justify-center text-gray-600 hover:text-gray-800 md:justify-start">
-                            <div class="flex">
-                                <svg
-                                    xmlns="http://www.w3.org/2000/svg"
-                                    viewBox="0 0 24 24"
-                                    fill="currentColor"
-                                    class="h-6 w-6"
-                                >
-                                    <path
-                                        fill-rule="evenodd"
-                                        d="M1.5 4.5a3 3 0 013-3h1.372c.86 0 1.61.586 1.819 1.42l1.105 4.423a1.875 1.875 0 01-.694 1.955l-1.293.97c-.135.101-.164.249-.126.352a11.285 11.285 0 006.697 6.697c.103.038.25.009.352-.126l.97-1.293a1.875 1.875 0 011.955-.694l4.423 1.105c.834.209 1.42.959 1.42 1.82V19.5a3 3 0 01-3 3h-2.25C8.552 22.5 1.5 15.448 1.5 6.75V4.5z"
-                                        clip-rule="evenodd"
-                                    /></svg
-                                ><span class="ml-3">office: +12(3)4567890123</span>
-                            </div></a
-                        >
-
-  
-
-        </div>
-
-
-      </div>
-      
-      <div>
-        <h5 class="pb-10 font-bold text-slate-100">Morocco</h5>
-        <ul>
-          <li class="pb-1 text-slate-100"><a href="#">Balakant Samat</a></li>
-          <li class="pb-1 text-slate-100"><a href="#">Rd.Essaouira Taghazout Bay</a></li>
-          <li class="pb-1 text-slate-100"><a href="#">Morocco</a></li>
-          
-        </ul>
-        <br>
-        <div>
-        
-<nav class="mb-10 list-none">
-                    <li class="mb-2">
-                        <a
-                            class="flex justify-center text-gray-600 hover:text-gray-800 md:justify-start">
-                            <div class="flex">
-                                <svg
-                                    xmlns="http://www.w3.org/2000/svg"
-                                    viewBox="0 0 24 24"
-                                    fill="currentColor"
-                                    class="h-6 w-6"
-                                >
-                                    <path
-                                        fill-rule="evenodd"
-                                        d="M1.5 4.5a3 3 0 013-3h1.372c.86 0 1.61.586 1.819 1.42l1.105 4.423a1.875 1.875 0 01-.694 1.955l-1.293.97c-.135.101-.164.249-.126.352a11.285 11.285 0 006.697 6.697c.103.038.25.009.352-.126l.97-1.293a1.875 1.875 0 011.955-.694l4.423 1.105c.834.209 1.42.959 1.42 1.82V19.5a3 3 0 01-3 3h-2.25C8.552 22.5 1.5 15.448 1.5 6.75V4.5z"
-                                        clip-rule="evenodd"
-                                    /></svg
-                                ><span class="ml-3">Ayoub: +12(3)4567890123</span>
-                            </div></a
-                        >
-                    </li>
-                    <nav class="mb-10 list-none">
-                    <li class="mb-2">
-                        <a
-                            class="flex justify-center text-gray-600 hover:text-gray-800 md:justify-start">
-                            <div class="flex">
-                                <svg
-                                    xmlns="http://www.w3.org/2000/svg"
-                                    viewBox="0 0 24 24"
-                                    fill="currentColor"
-                                    class="h-6 w-6"
-                                >
-                                    <path
-                                        fill-rule="evenodd"
-                                        d="M1.5 4.5a3 3 0 013-3h1.372c.86 0 1.61.586 1.819 1.42l1.105 4.423a1.875 1.875 0 01-.694 1.955l-1.293.97c-.135.101-.164.249-.126.352a11.285 11.285 0 006.697 6.697c.103.038.25.009.352-.126l.97-1.293a1.875 1.875 0 011.955-.694l4.423 1.105c.834.209 1.42.959 1.42 1.82V19.5a3 3 0 01-3 3h-2.25C8.552 22.5 1.5 15.448 1.5 6.75V4.5z"
-                                        clip-rule="evenodd"
-                                    /></svg
-                                ><span class="ml-3">office: +12(3)4567890123</span>
-                            </div></a
-                        >
-                    </li>
-        </div>
-
-
-      </div>
-      
-      <div>
-        <h5 class="pb-10 font-bold text-slate-100">Sri Lanka</h5>
-        <ul>
-          <li class="pb-1 text-slate-100"><a href="#">Balakant Samat,</a></li>
-          <li class="pb-1 text-slate-100"><a href="#">Sri Lanka</a></li>
-                  </ul>
-        <br>
-        <div class="flex">
-
-         <nav class="mb-10 list-none">
-                    <li class="mb-2">
-                        <a
-                            class="flex justify-center text-gray-600 hover:text-gray-800 md:justify-start">
-                            <div class="flex">
-                                <svg
-                                    xmlns="http://www.w3.org/2000/svg"
-                                    viewBox="0 0 24 24"
-                                    fill="currentColor"
-                                    class="h-6 w-6"
-                                >
-                                    <path
-                                        fill-rule="evenodd"
-                                        d="M1.5 4.5a3 3 0 013-3h1.372c.86 0 1.61.586 1.819 1.42l1.105 4.423a1.875 1.875 0 01-.694 1.955l-1.293.97c-.135.101-.164.249-.126.352a11.285 11.285 0 006.697 6.697c.103.038.25.009.352-.126l.97-1.293a1.875 1.875 0 011.955-.694l4.423 1.105c.834.209 1.42.959 1.42 1.82V19.5a3 3 0 01-3 3h-2.25C8.552 22.5 1.5 15.448 1.5 6.75V4.5z"
-                                        clip-rule="evenodd"
-                                    /></svg
-                                ><span class="ml-3">Jordy: +12(3)4567890123</span>
-                            </div></a
-                        >
-                    </li>
-                    <nav class="mb-10 list-none">
-                    <li class="mb-2">
-                        <a
-                            class="flex justify-center text-gray-600 hover:text-gray-800 md:justify-start">
-                            <div class="flex">
-                                <svg
-                                    xmlns="http://www.w3.org/2000/svg"
-                                    viewBox="0 0 24 24"
-                                    fill="currentColor"
-                                    class="h-6 w-6"
-                                >
-                                    <path
-                                        fill-rule="evenodd"
-                                        d="M1.5 4.5a3 3 0 013-3h1.372c.86 0 1.61.586 1.819 1.42l1.105 4.423a1.875 1.875 0 01-.694 1.955l-1.293.97c-.135.101-.164.249-.126.352a11.285 11.285 0 006.697 6.697c.103.038.25.009.352-.126l.97-1.293a1.875 1.875 0 011.955-.694l4.423 1.105c.834.209 1.42.959 1.42 1.82V19.5a3 3 0 01-3 3h-2.25C8.552 22.5 1.5 15.448 1.5 6.75V4.5z"
-                                        clip-rule="evenodd"
-                                    /></svg
-                                ><span class="ml-3">office: +12(3)4567890123</span>
-                            </div></a
-                        >
-
-      </div>
+<footer class="px-44 bg-slate-900 text-white ">
+    <div class="bg-blue-600 inline-flex rounded-full p-4 absolute right-24">
+        <button class="up text-white">
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
+                stroke="currentColor" class="w-6 h-6">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 15.75l7.5-7.5 7.5 7.5" />
+            </svg>
+        </button>
     </div>
 
-    <label for="input-group-1" class="block mb-2 text-sm font-medium text-slate-100">Newsletter Sign up</label>
-
-  <form>   
-    
-    <div class="relative">
-        <div class="flex absolute inset-y-0 left-0 items-center pl-3 pointer-events-none">
-            
+    <div class="content flex justify-between pt-24">
+        <div class="bali">
+            <div class="text-3xl font-semibold mb-6">
+                <h1>Bali</h1>
+            </div>
+            <div class="text-base mb-8 text-gray-400">
+                <p>
+                    Balakant Samat, <br />Gang Bekul Canggu – Kuta, <br />Indonesia
+                </p>
+            </div>
+            <div class="contact">
+                <div class="flex flex-row mb-6 text-gray-400">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
+                        stroke="currentColor" class="w-6 h-6">
+                        <path stroke-linecap="round" stroke-linejoin="round"
+                            d="M10.5 1.5H8.25A2.25 2.25 0 006 3.75v16.5a2.25 2.25 0 002.25 2.25h7.5A2.25 2.25 0 0018 20.25V3.75a2.25 2.25 0 00-2.25-2.25H13.5m-3 0V3h3V1.5m-3 0h3m-3 18.75h3" />
+                    </svg>
+                    <p>Berryl: +12 (3)456 7890 1234</p>
+                </div>
+                <div class="flex flex-row text-gray-400">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
+                        stroke="currentColor" class="w-6 h-6">
+                        <path stroke-linecap="round" stroke-linejoin="round"
+                            d="M10.5 1.5H8.25A2.25 2.25 0 006 3.75v16.5a2.25 2.25 0 002.25 2.25h7.5A2.25 2.25 0 0018 20.25V3.75a2.25 2.25 0 00-2.25-2.25H13.5m-3 0V3h3V1.5m-3 0h3m-3 18.75h3" />
+                    </svg>
+                    <p>Office: +12 (3)456 7890 1234</p>
+                </div>
+            </div>
         </div>
-        <input type="search" id="search" class="block p-4 pl-80  text-gray-900 bg-gray-50 rounded-lg border dark:text-white ">
-        
-        <button type="submit" class="text-white absolute right-2.5 bottom-2.5 bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-4 py-2 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800">Search</button>
+
+        <div class="morocco">
+            <div class="text-3xl font-semibold mb-6">
+                <h1>Morocco</h1>
+            </div>
+            <div class="text-base mb-8 text-gray-400">
+                <p>Balakant Samat <br />Rd.Essaouira Taghazout Bay <br />Morocco</p>
+            </div>
+            <div class="contact text-gray-400">
+                <div class="flex flex-row mb-6">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
+                        stroke="currentColor" class="w-6 h-6">
+                        <path stroke-linecap="round" stroke-linejoin="round"
+                            d="M10.5 1.5H8.25A2.25 2.25 0 006 3.75v16.5a2.25 2.25 0 002.25 2.25h7.5A2.25 2.25 0 0018 20.25V3.75a2.25 2.25 0 00-2.25-2.25H13.5m-3 0V3h3V1.5m-3 0h3m-3 18.75h3" />
+                    </svg>
+                    <p>Ayoub: +12 (3)456 7890 123</p>
+                </div>
+                <div class="flex flex-row">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
+                        stroke="currentColor" class="w-6 h-6">
+                        <path stroke-linecap="round" stroke-linejoin="round"
+                            d="M10.5 1.5H8.25A2.25 2.25 0 006 3.75v16.5a2.25 2.25 0 002.25 2.25h7.5A2.25 2.25 0 0018 20.25V3.75a2.25 2.25 0 00-2.25-2.25H13.5m-3 0V3h3V1.5m-3 0h3m-3 18.75h3" />
+                    </svg>
+                    <p>Office: +12 (3)456 7890 1234</p>
+                </div>
+            </div>
+        </div>
+
+        <div class="srilanka">
+            <div class="text-3xl font-semibold mb-6">
+                <h1>Sri Lanka</h1>
+            </div>
+            <div class="text-base mb-8 text-gray-400">
+                <p>Balakant Samat <br />Sri Lanka</p>
+            </div>
+            <div class="contact text-gray-400">
+                <div class="flex flex-row mb-6">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
+                        stroke="currentColor" class="w-6 h-6">
+                        <path stroke-linecap="round" stroke-linejoin="round"
+                            d="M10.5 1.5H8.25A2.25 2.25 0 006 3.75v16.5a2.25 2.25 0 002.25 2.25h7.5A2.25 2.25 0 0018 20.25V3.75a2.25 2.25 0 00-2.25-2.25H13.5m-3 0V3h3V1.5m-3 0h3m-3 18.75h3" />
+                    </svg>
+                    <p>Jordy: +12 (3)456 7890 123</p>
+                </div>
+                <div class="flex flex-row">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5"
+                        stroke="currentColor" class="w-6 h-6">
+                        <path stroke-linecap="round" stroke-linejoin="round"
+                            d="M10.5 1.5H8.25A2.25 2.25 0 006 3.75v16.5a2.25 2.25 0 002.25 2.25h7.5A2.25 2.25 0 0018 20.25V3.75a2.25 2.25 0 00-2.25-2.25H13.5m-3 0V3h3V1.5m-3 0h3m-3 18.75h3" />
+                    </svg>
+                    <p>Office: +12 (3)456 7890 1234</p>
+                </div>
+            </div>
+        </div>
     </div>
-</form>
-    
-    
 
-</div>
-
-
-  
-    <div class="pt-16 px-8 flex flex-col items-center gap-4">
-      <a href=""><img class="w-16 sm:w-20" src="https://i.ibb.co/tMdJ6Zs/Screen-Shot-2022-10-23-at-2-10-19-PM.png" alt="" border="0"></a>
-      <span class="text-slate-100 text-center">2018 Lift Media. All rights Reserved.</span>
-      <ul class="flex gap-5 items-center">
-        <li>
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6">
-            <path fill-rule="evenodd" d="M12 2.25c-5.385 0-9.75 4.365-9.75 9.75s4.365 9.75 9.75 9.75 9.75-4.365 9.75-9.75S17.385 2.25 12 2.25zm-2.625 6c-.54 0-.828.419-.936.634a1.96 1.96 0 00-.189.866c0 .298.059.605.189.866.108.215.395.634.936.634.54 0 .828-.419.936-.634.13-.26.189-.568.189-.866 0-.298-.059-.605-.189-.866-.108-.215-.395-.634-.936-.634zm4.314.634c.108-.215.395-.634.936-.634.54 0 .828.419.936.634.13.26.189.568.189.866 0 .298-.059.605-.189.866-.108.215-.395.634-.936.634-.54 0-.828-.419-.936-.634a1.96 1.96 0 01-.189-.866c0-.298.059-.605.189-.866zm-4.34 7.964a.75.75 0 01-1.061-1.06 5.236 5.236 0 013.73-1.538 5.236 5.236 0 013.695 1.538.75.75 0 11-1.061 1.06 3.736 3.736 0 00-2.639-1.098 3.736 3.736 0 00-2.664 1.098z" clip-rule="evenodd" />
-          </svg>
-        </li>
-        <li>
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6">
-            <path fill-rule="evenodd" d="M12 2.25c-5.385 0-9.75 4.365-9.75 9.75s4.365 9.75 9.75 9.75 9.75-4.365 9.75-9.75S17.385 2.25 12 2.25zm-2.625 6c-.54 0-.828.419-.936.634a1.96 1.96 0 00-.189.866c0 .298.059.605.189.866.108.215.395.634.936.634.54 0 .828-.419.936-.634.13-.26.189-.568.189-.866 0-.298-.059-.605-.189-.866-.108-.215-.395-.634-.936-.634zm4.314.634c.108-.215.395-.634.936-.634.54 0 .828.419.936.634.13.26.189.568.189.866 0 .298-.059.605-.189.866-.108.215-.395.634-.936.634-.54 0-.828-.419-.936-.634a1.96 1.96 0 01-.189-.866c0-.298.059-.605.189-.866zm2.023 6.828a.75.75 0 10-1.06-1.06 3.75 3.75 0 01-5.304 0 .75.75 0 00-1.06 1.06 5.25 5.25 0 007.424 0z" clip-rule="evenodd" />
-          </svg>
-        </li>
-        <li>
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6">
-            <path fill-rule="evenodd" d="M12 2.25c-5.385 0-9.75 4.365-9.75 9.75s4.365 9.75 9.75 9.75 9.75-4.365 9.75-9.75S17.385 2.25 12 2.25zm-2.625 6c-.54 0-.828.419-.936.634a1.96 1.96 0 00-.189.866c0 .298.059.605.189.866.108.215.395.634.936.634.54 0 .828-.419.936-.634.13-.26.189-.568.189-.866 0-.298-.059-.605-.189-.866-.108-.215-.395-.634-.936-.634zm4.314.634c.108-.215.395-.634.936-.634.54 0 .828.419.936.634.13.26.189.568.189.866 0 .298-.059.605-.189.866-.108.215-.395.634-.936.634-.54 0-.828-.419-.936-.634a1.96 1.96 0 01-.189-.866c0-.298.059-.605.189-.866zm-4.34 7.964a.75.75 0 01-1.061-1.06 5.236 5.236 0 013.73-1.538 5.236 5.236 0 013.695 1.538.75.75 0 11-1.061 1.06 3.736 3.736 0 00-2.639-1.098 3.736 3.736 0 00-2.664 1.098z" clip-rule="evenodd" />
-          </svg>
-        </li>
-        <li>
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="w-6 h-6">
-            <path fill-rule="evenodd" d="M12 2.25c-5.385 0-9.75 4.365-9.75 9.75s4.365 9.75 9.75 9.75 9.75-4.365 9.75-9.75S17.385 2.25 12 2.25zm-2.625 6c-.54 0-.828.419-.936.634a1.96 1.96 0 00-.189.866c0 .298.059.605.189.866.108.215.395.634.936.634.54 0 .828-.419.936-.634.13-.26.189-.568.189-.866 0-.298-.059-.605-.189-.866-.108-.215-.395-.634-.936-.634zm4.314.634c.108-.215.395-.634.936-.634.54 0 .828.419.936.634.13.26.189.568.189.866 0 .298-.059.605-.189.866-.108.215-.395.634-.936.634-.54 0-.828-.419-.936-.634a1.96 1.96 0 01-.189-.866c0-.298.059-.605.189-.866zm2.023 6.828a.75.75 0 10-1.06-1.06 3.75 3.75 0 01-5.304 0 .75.75 0 00-1.06 1.06 5.25 5.25 0 007.424 0z" clip-rule="evenodd" />
-          </svg>
-        </li>
-      </ul>
+    <div class="sign-up px-4 flex justify-center items-center mt-10 bg-gray-600 py-4 rounded-xl">
+        <h1 class="text-2xl font-semibold">Newsletter Sign Up</h1>
+        <div class="ml-16 w-8/12 bg-white py-2 px-6 rounded-md flex justify-between">
+            <input type="text" placeholder="Enter your email here." class="bg-transparent w-8/12" />
+            <button type="submit" class="bg-blue-600 py-2 px-6 rounded-md">
+                Submit
+            </button>
+        </div>
     </div>
-    <style>
-    </style>
-  </footer>
+
+    <div class="mt-8 px-24 py-8">
+        <div class="flex flex-row items-center justify-between">
+            <div><img
+                    src="https://res.cloudinary.com/atharva7/image/upload/v1666859658/samples/Logo_LIFT_icrenk.png"></img>
+            </div>
+            <div>
+                <p class="text-sm text-white">&COPY; Lift Media. All Rights Reserved.</p>
+            </div>
+            <div class="flex flex-row w-40 justify-between">
+                <span class="border border-gray-500 rounded-full p-2  "><svg class="w-6 h-6  fill-white"
+                        xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+                        <path
+                            d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z" />
+                    </svg></span>
+                <span class="border border-gray-500 rounded-full p-2"><svg xmlns="http://www.w3.org/2000/svg" width="24"
+                        height="24" fill="#0f172a" class="bi bi-linkedin bg-white" viewBox="0 0 16 16">
+                        <path
+                            d="M0 1.146C0 .513.526 0 1.175 0h13.65C15.474 0 16 .513 16 1.146v13.708c0 .633-.526 1.146-1.175 1.146H1.175C.526 16 0 15.487 0 14.854V1.146zm4.943 12.248V6.169H2.542v7.225h2.401zm-1.2-8.212c.837 0 1.358-.554 1.358-1.248-.015-.709-.52-1.248-1.342-1.248-.822 0-1.359.54-1.359 1.248 0 .694.521 1.248 1.327 1.248h.016zm4.908 8.212V9.359c0-.216.016-.432.08-.586.173-.431.568-.878 1.232-.878.869 0 1.216.662 1.216 1.634v3.865h2.401V9.25c0-2.22-1.184-3.252-2.764-3.252-1.274 0-1.845.7-2.165 1.193v.025h-.016a5.54 5.54 0 0 1 .016-.025V6.169h-2.4c.03.678 0 7.225 0 7.225h2.4z" />
+                    </svg></span> <span class="border border-gray-500 rounded-full p-2"><svg
+                        xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="white" class="bi bi-twitter"
+                        viewBox="0 0 16 16">
+
+                        <path
+                            d="M5.026 15c6.038 0 9.341-5.003 9.341-9.334 0-.14 0-.282-.006-.422A6.685 6.685 0 0 0 16 3.542a6.658 6.658 0 0 1-1.889.518 3.301 3.301 0 0 0 1.447-1.817 6.533 6.533 0 0 1-2.087.793A3.286 3.286 0 0 0 7.875 6.03a9.325 9.325 0 0 1-6.767-3.429 3.289 3.289 0 0 0 1.018 4.382A3.323 3.323 0 0 1 .64 6.575v.045a3.288 3.288 0 0 0 2.632 3.218 3.203 3.203 0 0 1-.865.115 3.23 3.23 0 0 1-.614-.057 3.283 3.283 0 0 0 3.067 2.277A6.588 6.588 0 0 1 .78 13.58a6.32 6.32 0 0 1-.78-.045A9.344 9.344 0 0 0 5.026 15z" />
+                    </svg></span>
+            </div>
+        </div>
+    </div>
+</footer>


### PR DESCRIPTION
Improved footer-dark-13. Footer-dark-13 was not as per the Figma design. So I updated it. 
Attached screenshots below:

Before:
![Screenshot (1927)](https://user-images.githubusercontent.com/66685553/206909668-ff90caa6-c9d0-443d-941c-ff42bf64250a.png)


After:
![Screenshot (1926)](https://user-images.githubusercontent.com/66685553/206909682-61cf46d8-af3b-4907-84d3-b5953c395d0d.png)

