### PR TITLE
Improved stats-2 and made it responsive

### DIFF
--- a/Stats/src/stats-2.html
+++ b/Stats/src/stats-2.html
@@ -1,24 +1,32 @@
-<div class="px-4 py-16 mx-auto sm:max-w-xl md:max-w-full lg:max-w-screen-xl md:px-24 lg:px-8 lg:py-20">
-  <div class="grid grid-cols-2 row-gap-8 md:grid-cols-4">
-    <div class="text-center md:border-r">
-      <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" class="ml-12 scale-105 mb-5"><path viewBox="-170 0 400 256" d="M38 18h-8V6H18v12h-8l14 14 14-14zM10 36v4h28v-4H10z"/><path fill="none" d="M0 0h48v48H0z"/></svg>
-      <h6 class="text-4xl font-bold lg:text-5xl xl:text-6xl">144K</h6>
-      <p class="text-sm font-medium tracking-widest text-gray-800 uppercase lg:text-base">
-        Downloads
-      </p>
+<div class="grid grid-cols-1 sm:grid-cols-3 gap-5 p-5">
+  <div class="flex flex-col items-center justify-center gap-4 p-5 border-2 border-gray-200 rounded-lg shadow-lg">
+    <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" class="scale-105">
+      <path viewBox="-170 0 400 256" d="M38 18h-8V6H18v12h-8l14 14 14-14zM10 36v4h28v-4H10z" fill="#2564eb" />
+    </svg>
+    <div class="text-center">
+      <h6 class="text-4xl font-semibold text-slate-900">144K</h6>
+      <p class="text-base font-medium uppercase tracking-widest text-slate-900">Downloads</p>
     </div>
-    <div class="text-center md:border-r">
-      <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" class="mt-4 ml-16 scale-150"><path fill="none" d="M0 0h24v24H0V0z"/><path d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92s2.92-1.31 2.92-2.92-1.31-2.92-2.92-2.92z"/></svg>
-      <h6 class="text-4xl font-bold lg:text-5xl xl:text-6xl">12.9K</h6>
-      <p class="text-sm font-medium tracking-widest text-gray-800 uppercase lg:text-base">
-        Subscribers
-      </p>
+  </div>
+  <div class="flex flex-col items-center justify-center gap-7 p-5 border-2 border-gray-200 rounded-lg shadow-lg">
+    <svg xmlns="http://www.w3.org/2000/svg" width="26" height="26" class="scale-[1.8] pt-1">
+      <path fill="#2564eb"
+        d="M18 16.08c-.76 0-1.44.3-1.96.77L8.91 12.7c.05-.23.09-.46.09-.7s-.04-.47-.09-.7l7.05-4.11c.54.5 1.25.81 2.04.81 1.66 0 3-1.34 3-3s-1.34-3-3-3-3 1.34-3 3c0 .24.04.47.09.7L8.04 9.81C7.5 9.31 6.79 9 6 9c-1.66 0-3 1.34-3 3s1.34 3 3 3c.79 0 1.5-.31 2.04-.81l7.12 4.16c-.05.21-.08.43-.08.65 0 1.61 1.31 2.92 2.92 2.92s2.92-1.31 2.92-2.92-1.31-2.92-2.92-2.92z" />
+    </svg>
+    <div class="text-center pt-2">
+      <h6 class="text-4xl font-semibold text-slate-900">12.9K</h6>
+      <p class="text-base font-medium uppercase tracking-widest text-slate-900">Subscribers</p>
     </div>
-    <div class="text-center md:border-r">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="-200 0 440 256" class="h-16 scale-75"><rect fill="none"/><circle cx="128" cy="96" r="64" fill="none" stroke="#000" stroke-miterlimit="10" stroke-width="16"/><path fill="none" stroke="#000" stroke-linecap="round" stroke-linejoin="round" stroke-width="16" d="M30.989,215.99064a112.03731,112.03731,0,0,1,194.02311.002"/></svg>
-      <h6 class="text-4xl font-bold lg:text-5xl xl:text-6xl">48.3K</h6>
-      <p class="text-sm font-medium tracking-widest text-gray-800 uppercase lg:text-base">
-        Users
-      </p>
+  </div>
+  <div class="flex flex-col items-center justify-center gap-2 p-5 border-2 border-gray-200 rounded-lg shadow-lg">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="-200 0 440 256" class="h-16 scale-90 pr-12">
+      <circle cx="128" cy="96" r="64" fill="none" stroke="#2564eb" stroke-miterlimit="10" stroke-width="16" />
+      <path fill="none" stroke="#2564eb" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"
+        d="M30.989,215.99064a112.03731,112.03731,0,0,1,194.02311.002" />
+    </svg>
+    <div class="text-center">
+      <h6 class="text-4xl font-semibold text-slate-900">48.3K</h6>
+      <p class="text-base font-medium uppercase tracking-widest text-slate-900">Users</p>
     </div>
+  </div>
 </div>


### PR DESCRIPTION
Closes #994 . Improved stats-2 and made it responsive. Screenshots attached.

## Before:
![Screenshot (2116)](https://user-images.githubusercontent.com/66685553/208286978-9463774f-0bbc-4573-b41d-d5a7688b78bd.png)

## After:
### 1. Desktop:
![Screenshot (2129)](https://user-images.githubusercontent.com/66685553/208286979-cc832ce3-bfd4-4619-88f6-63536015fad5.png)

### 2. Mobile:
![Screenshot (2130)](https://user-images.githubusercontent.com/66685553/208286998-73bc704e-70ce-466a-b21f-19edab64552d.png)
