### PR TITLE
Breadcrumb Design system updated

### DIFF
--- a/Breadcrumb/breadcrum.design-system.mdx
+++ b/Breadcrumb/breadcrum.design-system.mdx
@@ -8,8 +8,6 @@ It is quite similar to the navbar or even it is kind of navbar but main diffrenc
 
 ![Screenshot (52)](https://user-images.githubusercontent.com/73521123/206210245-3b26419d-bd2f-43cd-8bd0-67cf18ece4b3.png)
 
----
-
 ## General must known design system guideline :
 
 ### Color 🎨

--- a/Breadcrumb/breadcrum.design-system.mdx
+++ b/Breadcrumb/breadcrum.design-system.mdx
@@ -8,15 +8,6 @@ It is quite similar to the navbar or even it is kind of navbar but main diffrenc
 
 ![Screenshot (52)](https://user-images.githubusercontent.com/73521123/206210245-3b26419d-bd2f-43cd-8bd0-67cf18ece4b3.png)
 
-
-## Types of Badges 🔽
-
-1. Basic Breadcrumbs
-2. Active last breadcrumb
-3. Active last breadcrumb within button
-4. Breadcrumbs with icons
-5. Collapsed breadcrumbs
-
 ---
 
 ## General must known design system guideline :


### PR DESCRIPTION
For Issue #1072 
Updated Breadcrumb design system, removed whole Types of Badges section.
![image](https://user-images.githubusercontent.com/98400348/208484567-62b41e1a-2e28-4d1b-b47f-9f04b79f20bb.png)
