### PR TITLE
Improved footer-blue-14

### DIFF
--- a/Footer/src/footer-blue-14.html
+++ b/Footer/src/footer-blue-14.html
@@ -1,66 +1,76 @@
 <footer>
-    <div class="flex sm:flex-row-reverse min-[100px]:flex-col min-[100px]:items-center sm:items-end sm:justify-around p-4 ">
-        <div class="relative  lg:h-96 lg:w-96 md:h-80 md:w-80  h-56 w-56 rounded-full bg-[#F3F6FC] sm:mb-24">
-            <div class="relative  top-[5%] left-[5%]  h-[90%] w-[90%] rounded-full bg-[#E8EDF9]">
-                <img src="https://www.w3schools.com/w3css/img_lights.jpg" class="relative top-[5%] z-20 left-[5%] block h-[90%] w-[90%] rounded-full" alt="" />
+    <div
+        class="flex p-4 min-[100px]:flex-col min-[100px]:items-center sm:flex-row-reverse sm:items-end sm:justify-around">
+        <div class="relative h-56 w-56 rounded-full bg-[#F3F6FC] sm:mb-24 md:h-80 md:w-80 lg:h-96 lg:w-96">
+            <div class="relative top-[5%] left-[5%] h-[90%] w-[90%] rounded-full bg-[#E8EDF9]">
+                <img src="https://www.w3schools.com/w3css/img_lights.jpg"
+                    class="relative top-[5%] left-[5%] z-20 block h-[90%] w-[90%] rounded-full" alt="" />
             </div>
         </div>
-        <div class="flex flex-col-reverse z-20 min-[100px]:items-center  sm:items-start lg:mb-12">
-            <img class="h-8 w-16 min-[100px]:mb-6 sm:mb-0" src="https://res.cloudinary.com/atharva7/image/upload/v1666859658/samples/Logo_LIFT_icrenk.png" alt="">
-            <button class="bg-white w-48 p-2 rounded-3xl font-semibold mt-8 mb-8 lg:mt-12 lg:mb-12 text-sm">Kickstart Your Future</button>
-            <h1 class="text-white font-serif font-semibold md:text-4xl min-[100px]:text-3xl min-[100px]:text-center sm:text-start">Ready to get Started?</h1>
+        <div class="z-20 flex flex-col-reverse min-[100px]:items-center sm:items-start lg:mb-12">
+            <img class="h-14 w-28 min-[100px]:mb-6 sm:mb-0"
+                src="https://res.cloudinary.com/atharva7/image/upload/v1666859658/samples/Logo_LIFT_icrenk.png"
+                alt="" />
+            <button class="mt-8 mb-8 w-48 rounded-3xl bg-white p-2 text-sm font-semibold lg:mt-12 lg:mb-12">Kickstart
+                Your Future</button>
+            <h1 class="text-center font-serif text-3xl font-semibold text-white sm:text-start md:text-4xl">Ready to get
+                Started?</h1>
         </div>
     </div>
-    <div class="relative flex z-20 justify-around items-center min-[100px]:flex-col sm:flex-row">
-        <div class="flex lg:w-96 md:w-80 min-[100px]:mb-6 sm:mb-0">
-            <button class="bg-white rounded-3xl pl-2 pr-2 flex items-center h-8 mr-4"> <img class="h-4 w-4" src="https://cdn-icons-png.flaticon.com/512/0/747.png" alt=""/>
+    <div class="relative z-20 flex flex-col items-center justify-around md:flex-row">
+        <div class="mb-6 flex flex-col gap-4 min-[400px]:flex-row sm:mb-0">
+            <button class="mr-4 flex items-center gap-2 rounded-3xl bg-white px-4 py-2">
+                <img class="h-6 w-6" src="https://cdn-icons-png.flaticon.com/512/0/747.png" alt="" />
                 <div class="flex flex-col">
-                    <span class="text-[6px] font-semibold ">Download on the</span>
-                    <span class=" text-xs font-semibold">App store</span>
+                    <span class="text-xs font-semibold">Download on the</span>
+                    <span class="text-sm font-semibold">App store</span>
                 </div>
             </button>
-            <button class="bg-black rounded-3xl pl-2 pr-2 flex items-center h-8 text-white"><img class="h-4 w-4" src="https://cdn-icons-png.flaticon.com/512/3128/3128279.png" alt=""/><div class="flex flex-col">
-                <span class="text-[6px] font-semibold flex ">Get it on</span>
-                <span class=" text-xs font-semibold">Google Play</span>
+            <button class="mr-4 flex items-center gap-2 rounded-3xl bg-black px-5 py-2 text-white">
+                <img class="h-6 w-6" src="https://cdn-icons-png.flaticon.com/512/3128/3128279.png" alt="" />
+                <div class="flex flex-col">
+                    <span class="text-xs font-semibold">Get it on</span>
+                    <span class="text-sm font-semibold">Google play</span>
+                </div>
             </button>
         </div>
-        <div class="flex items-center lg:w-96 md:w-80 min-[100px]:flex-col-reverse sm:flex-row ">
-
-            <span class="text-xs  sm:text-center text-white">© 2019 Lift Media. All Rights Reserved.</span>
-            <div class="flex min-[100px]:mb-6 sm:mb-0">
-            <a href="#" >
-                <svg xmlns="http://www.w3.org/2000/svg" x="0px" y="0px"
-                class="h-6 m-4
-                width="16" height="16"
-                viewBox="0 0 16 16"
-                style=" fill:#FFFFFF;"><path d="M 15 3.296875 C 14.476563 3.523438 13.949219 3.691406 13.367188 3.746094 C 13.949219 3.410156 14.417969 2.84375 14.648438 2.226563 C 14.066406 2.5625 13.484375 2.789063 12.84375 2.902344 C 12.257813 2.339844 11.5 2 10.683594 2 C 9.109375 2 7.824219 3.242188 7.824219 4.765625 C 7.824219 4.988281 7.824219 5.214844 7.882813 5.386719 C 4.875 5.386719 2.8125 3.691406 1.414063 2 C 1.121094 2.394531 1.003906 2.902344 1.003906 3.410156 C 1.003906 4.367188 1.53125 5.214844 2.289063 5.722656 C 1.820313 5.667969 1.355469 5.554688 1.003906 5.386719 C 1.003906 5.386719 1.003906 5.386719 1.003906 5.441406 C 1.003906 6.796875 1.996094 7.921875 3.28125 8.148438 C 3.046875 8.203125 2.8125 8.261719 2.519531 8.261719 C 2.347656 8.261719 2.171875 8.261719 1.996094 8.207031 C 2.347656 9.335938 3.976563 10.632813 5.257813 10.632813 C 4.265625 11.363281 3.34375 12 1.5 12 C 1.265625 12 1.453125 12 1 12 C 2.28125 12.789063 3.800781 13 5.375 13 C 10.683594 13 13.542969 8.769531 13.542969 5.101563 C 13.542969 4.988281 13.542969 4.878906 13.542969 4.765625 C 14.125 4.367188 14.59375 3.863281 15 3.296875"></path>
-              </svg>
-            </a>
-            <a href="/">
-                <svg xmlns="http://www.w3.org/2000/svg" x="0px" y="0px"
-                class="h-6 m-4
-                width="50" height="50"
-                viewBox="0 0 50 50"
-                style=" fill:#fff;">    <path d="M 8 3.0097656 C 4.53 3.0097656 2.0097656 5.0892187 2.0097656 7.9492188 C 2.0097656 10.819219 4.59 12.990234 8 12.990234 C 11.47 12.990234 13.990234 10.870625 13.990234 7.890625 C 13.830234 5.020625 11.36 3.0097656 8 3.0097656 z M 3 15 C 2.45 15 2 15.45 2 16 L 2 45 C 2 45.55 2.45 46 3 46 L 13 46 C 13.55 46 14 45.55 14 45 L 14 16 C 14 15.45 13.55 15 13 15 L 3 15 z M 18 15 C 17.45 15 17 15.45 17 16 L 17 45 C 17 45.55 17.45 46 18 46 L 27 46 C 27.552 46 28 45.552 28 45 L 28 30 L 28 29.75 L 28 29.5 C 28 27.13 29.820625 25.199531 32.140625 25.019531 C 32.260625 24.999531 32.38 25 32.5 25 C 32.62 25 32.739375 24.999531 32.859375 25.019531 C 35.179375 25.199531 37 27.13 37 29.5 L 37 45 C 37 45.552 37.448 46 38 46 L 47 46 C 47.55 46 48 45.55 48 45 L 48 28 C 48 21.53 44.529063 15 36.789062 15 C 33.269062 15 30.61 16.360234 29 17.490234 L 29 16 C 29 15.45 28.55 15 28 15 L 18 15 z"></path>
-                </svg>
-            </a>
-            <a href="/">
-                <svg xmlns="http://www.w3.org/2000/svg" x="0px" y="0px"
-                class="h-6 m-4
-                width="50" height="50"
-                viewBox="0 0 50 50"
-                style=" fill:#fff;">    <path d="M32,11h5c0.552,0,1-0.448,1-1V3.263c0-0.524-0.403-0.96-0.925-0.997C35.484,2.153,32.376,2,30.141,2C24,2,20,5.68,20,12.368 V19h-7c-0.552,0-1,0.448-1,1v7c0,0.552,0.448,1,1,1h7v19c0,0.552,0.448,1,1,1h7c0.552,0,1-0.448,1-1V28h7.222 c0.51,0,0.938-0.383,0.994-0.89l0.778-7C38.06,19.518,37.596,19,37,19h-8v-5C29,12.343,30.343,11,32,11z"></path>
-              </svg> 
-            </a>
+        <div class="flex flex-col-reverse items-center sm:flex-row">
+            <span class="text-xs text-white sm:text-center">© 2019 Lift Media. All Rights Reserved.</span>
+            <div class="mb-6 flex sm:mb-0">
+                <a href="#">
+                    <svg xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" class="m-4 h-6" width="16" height="16"
+                        viewBox="0 0 16 16" style=" fill:#FFFFFF;">
+                        <path
+                            d="M 15 3.296875 C 14.476563 3.523438 13.949219 3.691406 13.367188 3.746094 C 13.949219 3.410156 14.417969 2.84375 14.648438 2.226563 C 14.066406 2.5625 13.484375 2.789063 12.84375 2.902344 C 12.257813 2.339844 11.5 2 10.683594 2 C 9.109375 2 7.824219 3.242188 7.824219 4.765625 C 7.824219 4.988281 7.824219 5.214844 7.882813 5.386719 C 4.875 5.386719 2.8125 3.691406 1.414063 2 C 1.121094 2.394531 1.003906 2.902344 1.003906 3.410156 C 1.003906 4.367188 1.53125 5.214844 2.289063 5.722656 C 1.820313 5.667969 1.355469 5.554688 1.003906 5.386719 C 1.003906 5.386719 1.003906 5.386719 1.003906 5.441406 C 1.003906 6.796875 1.996094 7.921875 3.28125 8.148438 C 3.046875 8.203125 2.8125 8.261719 2.519531 8.261719 C 2.347656 8.261719 2.171875 8.261719 1.996094 8.207031 C 2.347656 9.335938 3.976563 10.632813 5.257813 10.632813 C 4.265625 11.363281 3.34375 12 1.5 12 C 1.265625 12 1.453125 12 1 12 C 2.28125 12.789063 3.800781 13 5.375 13 C 10.683594 13 13.542969 8.769531 13.542969 5.101563 C 13.542969 4.988281 13.542969 4.878906 13.542969 4.765625 C 14.125 4.367188 14.59375 3.863281 15 3.296875">
+                        </path>
+                    </svg>
+                </a>
+                <a href="/">
+                    <svg xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" class="m-4 h-6" width="50" height="50"
+                        viewBox="0 0 50 50" style=" fill:#fff;">
+                        <path
+                            d="M 8 3.0097656 C 4.53 3.0097656 2.0097656 5.0892187 2.0097656 7.9492188 C 2.0097656 10.819219 4.59 12.990234 8 12.990234 C 11.47 12.990234 13.990234 10.870625 13.990234 7.890625 C 13.830234 5.020625 11.36 3.0097656 8 3.0097656 z M 3 15 C 2.45 15 2 15.45 2 16 L 2 45 C 2 45.55 2.45 46 3 46 L 13 46 C 13.55 46 14 45.55 14 45 L 14 16 C 14 15.45 13.55 15 13 15 L 3 15 z M 18 15 C 17.45 15 17 15.45 17 16 L 17 45 C 17 45.55 17.45 46 18 46 L 27 46 C 27.552 46 28 45.552 28 45 L 28 30 L 28 29.75 L 28 29.5 C 28 27.13 29.820625 25.199531 32.140625 25.019531 C 32.260625 24.999531 32.38 25 32.5 25 C 32.62 25 32.739375 24.999531 32.859375 25.019531 C 35.179375 25.199531 37 27.13 37 29.5 L 37 45 C 37 45.552 37.448 46 38 46 L 47 46 C 47.55 46 48 45.55 48 45 L 48 28 C 48 21.53 44.529063 15 36.789062 15 C 33.269062 15 30.61 16.360234 29 17.490234 L 29 16 C 29 15.45 28.55 15 28 15 L 18 15 z">
+                        </path>
+                    </svg>
+                </a>
+                <a href="/">
+                    <svg xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" class="m-4 h-6" width="50" height="50"
+                        viewBox="0 0 50 50" style=" fill:#fff;">
+                        <path
+                            d="M32,11h5c0.552,0,1-0.448,1-1V3.263c0-0.524-0.403-0.96-0.925-0.997C35.484,2.153,32.376,2,30.141,2C24,2,20,5.68,20,12.368 V19h-7c-0.552,0-1,0.448-1,1v7c0,0.552,0.448,1,1,1h7v19c0,0.552,0.448,1,1,1h7c0.552,0,1-0.448,1-1V28h7.222 c0.51,0,0.938-0.383,0.994-0.89l0.778-7C38.06,19.518,37.596,19,37,19h-8v-5C29,12.343,30.343,11,32,11z">
+                        </path>
+                    </svg>
+                </a>
             </div>
-            
         </div>
     </div>
-    <div class=" relative -mt-[28rem] sm:-mt-64 md:-mt-80 lg:-mt-96 w-screen z-10 overflow-x-hidden max-w-full ">
-        <svg  viewBox="0 0 2880 1250" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path fill-rule="evenodd" clip-rule="evenodd" d="M2880 111.454V1252H0V111.291C438.836 39.8071 926.219 0 1439.5 0C1953.17 0 2440.9 39.8679 2880 111.454Z" fill="#1855CB"/>
-            </svg>
-        <div class="w-screen sm:hidden bg-[#1855CB] h-96 -mt-12">
-        </div>
+    <div
+        class="relative z-10 -mt-[34rem] w-screen max-w-full overflow-x-hidden min-[400px]:-mt-[30rem] sm:-mt-[22rem] md:-mt-80 lg:-mt-96">
+        <svg viewBox="0 0 2880 1250" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <path fill-rule="evenodd" clip-rule="evenodd"
+                d="M2880 111.454V1252H0V111.291C438.836 39.8071 926.219 0 1439.5 0C1953.17 0 2440.9 39.8679 2880 111.454Z"
+                fill="#1855CB" />
+        </svg>
+        <div class="h-[30rem] w-screen bg-[#1855CB] min-[400px]:h-[24rem] sm:h-36 md:h-10 lg:hidden"></div>
     </div>
 </footer>


### PR DESCRIPTION
Closes #1226 . Improved footer-blue-14. Screenshot attached.
![Screenshot (2415)](https://user-images.githubusercontent.com/66685553/209442003-0fd83514-3281-475a-bf86-440502f43311.png)
