### PR TITLE
feat: Add dynamic year, copyright symbol, and ClueLess link in footer

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,7 +1,12 @@
 import { Tooltip } from "@chakra-ui/react";
 import Link from "next/link";
-import React from "react";
+import React, { useState, useEffect } from "react";
 function Footer() {
+  const [currentYear, setCurrentYear] = useState(new Date().getFullYear());
+
+  useEffect(() => {
+    setCurrentYear(new Date().getFullYear());
+  }, []);
   return (
     <div className="p-10 bg-[#1B1B1B] space-y-8">
       <div className="flex justify-between p-5 flex-col md:flex-row md:text-left text-center space-y-1">
@@ -89,7 +94,8 @@ function Footer() {
           <Link
             href={
               "https://github.com/Clueless-Community/seamless-ui/issues/new?title=Report%20an%20Issue%20%3F&labels=feedback"
-            } target={"_blank"}
+            }
+            target={"_blank"}
           >
             <p className="md:text-xl text-md text-white hover:text-[#7EE787] transition-all cursor-pointer">
               Report an Issue
@@ -131,9 +137,27 @@ function Footer() {
       <div className="-mx-10 md:-mx-0 ">
         <div className="md:flex md:justify-between text-center md:px-6 ">
           <p className="bg-[#7EE787] md:bg-transparent text-white py-2">
-            Copyright 2023 by ClueLess
+            &copy; {currentYear} by{" "}
+            <a
+              href="https://www.clueless.live/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-semibold"
+            >
+              ClueLess
+            </a>
           </p>
-          <p className="text-white hidden md:block">Powered by Clueless</p>
+          <p className="text-white hidden md:block">
+            Powered by{" "}
+            <a
+              href="https://www.clueless.live/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-semibold"
+            >
+              ClueLess
+            </a>
+          </p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This PR solves issue number #2252 

This pull request implements the following updates to the footer section:

1. Dynamic Year: The year in the footer is now dynamically generated using JavaScript to always display the current year.

2. Copyright Symbol: The copyright symbol "©" has been added before the year to conform to copyright formatting conventions.

3. ClueLess Link: The text "ClueLess" in the footer has been transformed into a clickable link. Clicking on it will redirect the user to the ClueLess website (https://www.clueless.live/). Furthermore, the link has been set to open in a new tab to enhance user experience.

These changes improve the footer by ensuring the year is always up to date, incorporating the copyright symbol, and providing a convenient link to the ClueLess website.

After merging this PR the result will be like below 👇

![Screenshot 2023-06-02 015647](https://github.com/Clueless-Community/seamless-ui/assets/96189881/bab8a693-49c7-4451-979e-7d184e1d5b69)