### PR TITLE
Getting Started Button Issue Fixed

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -19,7 +19,7 @@ const Hero = () => {
         </div>
         <div className=" flex flex-col md:flex-row pt-10 md:justify-center items-center  md:space-x-7 space-y-7 md:space-y-0 pb-28">
           <Link href="/docs/getting-started">
-            <button className="w-fit bg-[#7EE787] border-2 border-[#7EE787] hover:bg-green-800 transition-all hover:border-green-800 active:scale-95 p-2 rounded-lg px-6 font-semibold">
+            <button className="text-black hover:text-white w-fit bg-[#7EE787] border-2 border-[#7EE787] hover:bg-green-800 transition-all hover:border-green-800 active:scale-95 p-2 rounded-lg px-6 font-semibold">
               Getting Started
             </button>
           </Link>


### PR DESCRIPTION
closes #2260 

Getting started button text color should be black and on hover it should be white 
Now I added text-black and hover:text-white
so the button design is now as per figma design