### PR TITLE
Fix typo in Tutorial.md

### DIFF
--- a/Tutorial.md
+++ b/Tutorial.md
@@ -51,7 +51,7 @@ A great resource to learn the fundamentals of HTML is [W3 Schools](https://www.w
 
 ## CSS
 
-&nbsp;&nbsp;&nbsp;&nbsp;CSS stands for Cascading Style Sheets and they are what gives style to the HTML elements. The presentation of a piece of software is very important to the end user experience and it is often dictated by the CSS, but have no fear getting started is easy (mastering it is altogether different). Just like with HTML othere are some great resources on the web to help you start writing your first CSS, among them are [***Mozilla's intorductory guide***](https://developer.mozilla.org/en-US/docs/Learn/CSS/First_steps/Getting_started) and once again our friends at [***W3 Schools***](https://www.w3schools.com/css/). 
+&nbsp;&nbsp;&nbsp;&nbsp;CSS stands for Cascading Style Sheets and they are what gives style to the HTML elements. The presentation of a piece of software is very important to the end user experience and it is often dictated by the CSS, but have no fear getting started is easy (mastering it is altogether different). Just like with HTML, there are some great resources on the web to help you start writing your first CSS, among them are [***Mozilla's introductory guide***](https://developer.mozilla.org/en-US/docs/Learn/CSS/First_steps/Getting_started) and once again our friends at [***W3 Schools***](https://www.w3schools.com/css/). 
 
 As for an intro to CSS video [***Web Dev Simplified***](https://www.youtube.com/watch?v=1PnVor36_40) has a great video to show you the basics.
 


### PR DESCRIPTION
Fixed some Typo errors in the Tutorial.md file for better readability

`intorductory`  -> `introductory`
`othere` -> `there`

![image](https://github.com/Clueless-Community/seamless-ui/assets/133729421/5682183c-752c-4bc6-a35e-23c5bc962127)
